### PR TITLE
Updating Dockerfile for PS2 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,16 +9,16 @@ RUN apt-get update && \
         python3 \
         wget
 
-RUN wget \
-        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
-        -O qemu.deb && \
-    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
-    dpkg -i qemu.deb && \
-    rm qemu.deb
+RUN wget https://github.com/ps2dev/ps2dev/releases/download/v1.1/ps2dev-ubuntu-latest.tar.gz && \
+    echo 6bd7352ff526239e928f5200b43afa96bdef04ecf48d15386bac954938b514a1 ps2dev-ubuntu-latest.tar.gz | sha256sum --check && \
+    tar xzf ps2dev-ubuntu-latest.tar.gz && \
+    rm ps2dev-ubuntu-latest.tar.gz
 
 RUN mkdir /sm64
 WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
+ENV PATH="/ps2dev/ee/bin:/ps2dev/iop/bin:/sm64/tools:${PATH}"
+ENV PS2SDK=/ps2dev/ps2sdk
+ENV GSKIT=/ps2dev/gsKit
 
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4'
+


### PR DESCRIPTION
Docker build instructions:

**1. Checkout repo, submodules etc**
```
git clone https://github.com/fgsfdsfgs/sm64-port.git
cd sm64-port 
git checkout ps2 && git submodule update --init
```

**2. Copy in your baserom.XX.z64**
```
cp /path/to/baserom.us.z64 . # change 'us' for 'eu', 'jp' or 'sh' as necessary
```

**3. Build docker image**
```
docker build . -t sm64_ps2
```

**4. Compile with using your docker image**
```
docker run --rm -ti -v $(pwd):/sm64 sm64_ps2 make --jobs 4
```

**5. Find your .elf**
```
ls -al build/us_ps2/sm64.us.f3dex2e.elf
```