### PR TITLE
Updating Dockerfile for PS3 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,59 @@
+FROM ubuntu:18.04 as ps3toolchain
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+  apt-get -y update && \
+  apt-get -y install \
+  autoconf bison build-essential ca-certificates flex git libelf-dev\
+  libgmp-dev libncurses5-dev libssl-dev libtool-bin pkg-config python-dev \
+  texinfo wget zlib1g-dev && \
+  apt-get -y clean autoclean autoremove && \
+  rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+RUN mkdir /build
+WORKDIR /build
+
+COPY . /build
+
+# Fixes certificate errors with letsencrypt in ARMv7
+RUN echo "\nca_certificate=/etc/ssl/certs/ca-certificates.crt" | tee -a /etc/wgetrc
+
+ENV PS3DEV /ps3dev
+ENV PSL1GHT ${PS3DEV}
+ENV PATH ${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
+
+RUN /build/toolchain.sh
+
+###
+
 FROM ubuntu:18.04 as build
 
 RUN apt-get update && \
-    apt-get install -y \
-        binutils-mips-linux-gnu \
-        bsdmainutils \
-        build-essential \
-        libaudiofile-dev \
-        python3 \
-        wget
+  apt-get install -y \
+    binutils-mips-linux-gnu \
+    bsdmainutils \
+    build-essential \
+    libaudiofile-dev \
+    libelf-dev \
+    pkg-config \
+    python3 \
+    wget \
+    zlib1g-dev
 
-RUN wget \
-        https://github.com/n64decomp/qemu-irix/releases/download/v2.11-deb/qemu-irix-2.11.0-2169-g32ab296eef_amd64.deb \
-        -O qemu.deb && \
-    echo 8170f37cf03a08cc2d7c1c58f10d650ea0d158f711f6916da9364f6d8c85f741 qemu.deb | sha256sum --check && \
-    dpkg -i qemu.deb && \
-    rm qemu.deb
+RUN wget http://developer.download.nvidia.com/cg/Cg_3.1/Cg-3.1_April2012_x86_64.deb && \
+  echo '6da24fd6698dbb43ae5eee8691817d88d5792d89e2e8b9acf07597bec35cb080  Cg-3.1_April2012_x86_64.deb' \
+    | sha256sum Cg-3.1_April2012_x86_64.deb && \
+  dpkg -i Cg-3.1_April2012_x86_64.deb && \
+  rm Cg-3.1_April2012_x86_64.deb
+
+COPY --from=ps3toolchain /ps3dev /ps3dev
+
+ENV PS3DEV /ps3dev
+ENV PSL1GHT ${PS3DEV}
+ENV PATH ${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
 
 RUN mkdir /sm64
 WORKDIR /sm64
-ENV PATH="/sm64/tools:${PATH}"
 
-CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4\n' \
-         'see https://github.com/n64decomp/sm64/blob/master/README.md for advanced usage'
+CMD echo 'usage: docker run --rm -v $(pwd):/sm64 sm64 make VERSION=${VERSION:-us} -j4\n'


### PR DESCRIPTION
It includes building the ps3 toolchain too, so I'd recommend just pulling `markstreet/sm64:ps3` to save yourself an hour or so of build time..