### PR TITLE
rename to rsxSetZMinMaxControl

### DIFF
--- a/src/pc/gfx/gfx_ps3_rapi.c
+++ b/src/pc/gfx/gfx_ps3_rapi.c
@@ -447,7 +447,7 @@ static inline void draw_set_environment(void) {
     rsxSetColorMaskMrt(rsx_ctx, 0);
     rsxSetClearColor(rsx_ctx, 0);
     rsxSetClearDepthStencil(rsx_ctx, 0xffffff00);
-    rsxSetZControl(rsx_ctx, 1, 1, 0);
+    rsxSetZMinMaxControl(rsx_ctx, 1, 1, 0);
     rsxSetUserClipPlaneControl(
         rsx_ctx,
         GCM_USER_CLIP_PLANE_DISABLE,


### PR DESCRIPTION
See https://github.com/ps3dev/PSL1GHT/commit/948eed15888240c7387c009c686d664f3ff6495f

Not sure if this will effect the docker build but that was broken for me when I tried it, this fixes using the latest toolchain, so if your targeting a specific version you would also want to target the latest toolchain.