### PR TITLE
PS2: Make $USE_NEW_PS2SDK available to all make's child processes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ ifeq ($(TARGET_PS2),1)
     ifeq ($(EE_CC_VERSION),)
       $(error No valid GCC found in PATH)
     else
-      USE_NEW_PS2SDK := 1
+      export USE_NEW_PS2SDK := 1
     endif
   endif
   endif


### PR DESCRIPTION
Make the variable USE_NEW_PS2SDK available to all make's child processes so that building ps2-audsrv with the new SDK does not fail under Ubuntu 20.04.