### PR TITLE
PS2: Fix compilation with new SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ ifeq ($(TARGET_PS2),1)
     ifeq ($(EE_CC_VERSION),)
       $(error No valid GCC found in PATH)
     else
-      USE_NEW_PS2SDK := 1
+      export USE_NEW_PS2SDK := 1
     endif
   endif
   endif

--- a/src/pc/gfx/gfx_ps2_wapi.c
+++ b/src/pc/gfx/gfx_ps2_wapi.c
@@ -54,7 +54,6 @@ static bool do_render = true;
 
 static volatile unsigned int vblank_count = 0;
 static int vsync_callback_id = -1;
-volatile bool render_finished;
 
 static int vsync_callback(void) {
     if (render_finished) gsKit_display_buffer(gs_global); // working buffer gets displayed


### PR DESCRIPTION
1. Make the variable USE_NEW_PS2SDK available to all make's child processes so that building ps2-audsrv with the new SDK does not fail under Ubuntu 20.04.

2. Remove the duplicate definition of a variable to avoid the following error:

/usr/local/ps2dev/ee/lib/gcc/mips64r5900el-ps2-elf/11.1.0/../../../../mips64r5900el-ps2-elf/bin/ld: build/us_ps2/src/pc/gfx/gfx_ps2_wapi.o:(.bss+0x0): multiple definition of `render_finished'; build/us_ps2/src/pc/gfx/gfx_ps2_rapi.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status