### PR TITLE
Improvements PS2 New toolchain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ps2/ps2-audsrv"]
-	path = ps2/ps2-audsrv
-	url = https://github.com/fgsfdsfgs/ps2-audsrv.git

--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ ifeq ($(TARGET_PS2),1)
   C_FILES += $(AUDSRV_IRX).c $(FREESD_IRX).c $(BUILD_DIR)/ps2_icon.c
   O_FILES += $(AUDSRV_IRX).o $(FREESD_IRX).o $(BUILD_DIR)/ps2_icon.o
   PLATFORM_CFLAGS  := -DTARGET_PS2 -D_EE -G0 -I$(AUDSRV)/ee/rpc/audsrv/include -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(GSKIT)/include
-  PLATFORM_LDFLAGS := -L$(GSKIT)/lib -lgskit -ldmakit $(AUDSRV_LIB) -L$(PS2SDK)/ee/lib -lpad -lmc -ldma -lcdvd -lpatches -lm -lc -lkernel
+  PLATFORM_LDFLAGS := -L$(GSKIT)/lib -lgskit -ldmakit $(AUDSRV_LIB) -L$(PS2SDK)/ee/lib -lpad -lmc -ldma -lcdvd -lpatches
   ifneq ($(USE_NEW_PS2SDK),1)
     PLATFORM_ASFLAGS := --32 -march=generic32
   endif

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ TARGET_N64 ?= 0
 TARGET_WEB ?= 0
 # Build for PS2
 TARGET_PS2 ?= 1
-# Use the WIP GCC9+ toolchain
-USE_NEW_PS2SDK ?= 0
 # Compiler to use (ido or gcc)
 COMPILER ?= ido
 
@@ -245,22 +243,6 @@ ifeq ($(COMPILER),gcc)
   MIPSISET := -mips3
 endif
 
-ifeq ($(TARGET_PS2),1)
-  # try to detect GCC version
-  EE_CC_VERSION := $(shell ee-gcc -dumpversion 2> /dev/null)
-  ifneq ($(EE_CC_VERSION),3.2.2)
-  ifneq ($(EE_CC_VERSION),3.2.3)
-    # maybe new SDK?
-    EE_CC_VERSION := $(shell mips64r5900el-ps2-elf-gcc -dumpversion 2> /dev/null)
-    ifeq ($(EE_CC_VERSION),)
-      $(error No valid GCC found in PATH)
-    else
-      export USE_NEW_PS2SDK := 1
-    endif
-  endif
-  endif
-endif
-
 ifeq ($(TARGET_N64),1)
 
 ifeq ($(VERSION),eu)
@@ -281,7 +263,7 @@ endif
 else
 ifeq ($(TARGET_WEB),1)
   OPT_FLAGS := -O2 -g4 --source-map-base http://localhost:8080/
-else ifeq ($(USE_NEW_PS2SDK),1)
+else ifeq ($(TARGET_PS2),1)
   OPT_FLAGS := -O3 -fno-tree-builtin-call-dce -fno-strict-aliasing
 
 else
@@ -452,16 +434,9 @@ else # TARGET_N64
 
 
 ifeq ($(TARGET_PS2),1)
-  ifeq ($(PS2SDK),)
-    $(error PS2SDK is not defined)
-  endif
-  ifeq ($(USE_NEW_PS2SDK),1)
-    EE_PREFIX ?= mips64r5900el-ps2-elf-
-    EE_AS_PREFIX ?= $(EE_PREFIX)
-  else
-    EE_PREFIX ?= ee-
-    EE_AS_PREFIX ?=
-  endif
+  EE_PREFIX ?= mips64r5900el-ps2-elf-
+  EE_AS_PREFIX ?= $(EE_PREFIX)
+
   CC = $(EE_PREFIX)gcc -std=gnu99
   CXX= $(EE_PREFIX)g++ -std=gnu99
   CPP= $(EE_PREFIX)cpp -P
@@ -511,10 +486,7 @@ ifeq ($(TARGET_PS2),1)
   C_FILES += $(AUDSRV_IRX).c $(FREESD_IRX).c $(BUILD_DIR)/ps2_icon.c
   O_FILES += $(AUDSRV_IRX).o $(FREESD_IRX).o $(BUILD_DIR)/ps2_icon.o
   PLATFORM_CFLAGS  := -DTARGET_PS2 -D_EE -G0 -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(GSKIT)/include
-  PLATFORM_LDFLAGS := -L$(GSKIT)/lib -lgskit -ldmakit -L$(PS2SDK)/ee/lib -laudsrv -lpad -lmc -ldma -lcdvd -lpatches
-  ifneq ($(USE_NEW_PS2SDK),1)
-    PLATFORM_ASFLAGS := --32 -march=generic32
-  endif
+  PLATFORM_LDFLAGS := -Wl,-zmax-page-size=128 -L$(GSKIT)/lib -lgskit -ldmakit -L$(PS2SDK)/ee/lib -laudsrv -lpad -lmc -ldma -lcdvd -lpatches
 endif
 
 PLATFORM_CFLAGS += -DNO_SEGMENTED_MEMORY

--- a/Makefile
+++ b/Makefile
@@ -505,15 +505,13 @@ ifeq ($(TARGET_WEB),1)
   PLATFORM_LDFLAGS := -lm -no-pie -s TOTAL_MEMORY=20MB -g4 --source-map-base http://localhost:8080/ -s "EXTRA_EXPORTED_RUNTIME_METHODS=['callMain']"
 endif
 ifeq ($(TARGET_PS2),1)
-  AUDSRV     := ps2/ps2-audsrv
   AUDSRV_IRX := $(BUILD_DIR)/audsrv_irx
-  AUDSRV_LIB := $(BUILD_DIR)/libaudsrv.a
   FREESD_IRX := $(BUILD_DIR)/freesd_irx
   PS2_ICON   := ps2/sm64.icn
   C_FILES += $(AUDSRV_IRX).c $(FREESD_IRX).c $(BUILD_DIR)/ps2_icon.c
   O_FILES += $(AUDSRV_IRX).o $(FREESD_IRX).o $(BUILD_DIR)/ps2_icon.o
-  PLATFORM_CFLAGS  := -DTARGET_PS2 -D_EE -G0 -I$(AUDSRV)/ee/rpc/audsrv/include -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(GSKIT)/include
-  PLATFORM_LDFLAGS := -L$(GSKIT)/lib -lgskit -ldmakit $(AUDSRV_LIB) -L$(PS2SDK)/ee/lib -lpad -lmc -ldma -lcdvd -lpatches
+  PLATFORM_CFLAGS  := -DTARGET_PS2 -D_EE -G0 -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(GSKIT)/include
+  PLATFORM_LDFLAGS := -L$(GSKIT)/lib -lgskit -ldmakit -L$(PS2SDK)/ee/lib -laudsrv -lpad -lmc -ldma -lcdvd -lpatches
   ifneq ($(USE_NEW_PS2SDK),1)
     PLATFORM_ASFLAGS := --32 -march=generic32
   endif
@@ -601,22 +599,14 @@ endif
 
 ifeq ($(TARGET_PS2),1)
 
-$(EXE): $(AUDSRV_LIB)
-
 $(FREESD_IRX).c:
 	$(PS2SDK)/bin/bin2c $(PS2SDK)/iop/irx/freesd.irx $@ ps2_freesd_irx
 
-$(AUDSRV_IRX).c: audsrv
-	$(PS2SDK)/bin/bin2c $(AUDSRV)/iop/sound/audsrv/irx/audsrv.irx $@ ps2_audsrv_irx
+$(AUDSRV_IRX).c:
+	$(PS2SDK)/bin/bin2c $(PS2SDK)/iop/irx/audsrv.irx $@ ps2_audsrv_irx
 
 $(BUILD_DIR)/ps2_icon.c: $(PS2_ICON)
 	$(PS2SDK)/bin/bin2c $^ $@ ps2_icon_data
-
-$(AUDSRV_LIB): audsrv
-	cp -f $(AUDSRV)/ee/rpc/audsrv/lib/libaudsrv.a $@
-
-audsrv:
-	make -C $(AUDSRV)
 
 $(BUILD_DIR)/src/pc/audio/audio_ps2.o: $(AUDSRV_IRX).o $(FREESD_IRX).o
 
@@ -624,7 +614,6 @@ endif
 
 clean:
 	$(RM) -r $(BUILD_DIR_BASE)
-	@make -C $(AUDSRV) clean
 
 distclean:
 	$(RM) -r $(BUILD_DIR_BASE)

--- a/src/pc/gfx/gfx_ps2_wapi.c
+++ b/src/pc/gfx/gfx_ps2_wapi.c
@@ -75,11 +75,17 @@ static void gfx_ps2_init(const char *game_name, bool start_in_fullscreen) {
 
     vsync_callback_id = gsKit_add_vsync_handler(&vsync_callback);
 
-    if (gsKit_detect_signal() == GS_MODE_NTSC)
-        vid_mode = &vid_modes[0];
-    else
-        vid_mode = &vid_modes[2];
+#if defined(VERSION_EU)
+    vid_mode = &vid_modes[2]; // PAL
+#else
+    vid_mode = &vid_modes[0]; // NTCS
+#endif
 
+    gs_global->Mode = vid_mode->mode;
+    gs_global->Width = vid_mode->width;
+    gs_global->Height = vid_mode->height;
+    gs_global->Interlace = vid_mode->interlace;
+    gs_global->Field = vid_mode->field;
     gs_global->ZBuffering = GS_SETTING_ON;
     gs_global->DoubleBuffering = GS_SETTING_ON;
     gs_global->PrimAAEnable = GS_SETTING_OFF;

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,6 +1,6 @@
 CC := gcc
 CXX := g++
-CFLAGS := -I . -Wall -Wextra -Wno-unused-parameter -pedantic -std=c99 -O2 -s
+CFLAGS := -I . -Wall -Wextra -Wno-unused-parameter -Wno-error=implicit-function-declaration -pedantic -std=c99 -O2 -s
 LDFLAGS := -lm
 PROGRAMS := n64graphics n64graphics_ci mio0 n64cksum textconv patch_libultra_math aifc_decode aiff_extract_codebook vadpcm_enc tabledesign extract_data_for_mio skyconv
 
@@ -16,7 +16,7 @@ endif
 default: all
 
 armips: armips.cpp
-	$(CXX) $(CXXFLAGS) -fno-exceptions -fno-rtti -pipe $^ -o $@ -lpthread $(ARMIPS_FLAGS)
+	$(CXX) $(CXXFLAGS) -fno-exceptions -fno-rtti -pipe -std=c++11 -stdlib=libc++ $^ -o $@ -lpthread $(ARMIPS_FLAGS)
 
 n64graphics_SOURCES := n64graphics.c utils.c
 n64graphics_CFLAGS  := -DN64GRAPHICS_STANDALONE


### PR DESCRIPTION
# Description
This PR prepares the project for being compiled with the new toolchain.
It also removes current dependency with the audio driver, so after this PR is merged https://github.com/ps2dev/ps2sdk/pull/227
we can also merge this one.

It also uses ROM version to either use PAL or NTCS configuration in the PS2.

Additionally, some fixes were needed, to make it for compiling the `tools` in OSX using `CLANG`

Thanks