### PR TITLE
update Dockerfile with newer ps2dev sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
         python3 \
         wget
 
-RUN wget https://github.com/ps2dev/ps2dev/releases/download/v1.1/ps2dev-ubuntu-latest.tar.gz && \
-    echo 6bd7352ff526239e928f5200b43afa96bdef04ecf48d15386bac954938b514a1 ps2dev-ubuntu-latest.tar.gz | sha256sum --check && \
+RUN wget https://github.com/ps2dev/ps2dev/releases/download/latest/ps2dev-ubuntu-latest.tar.gz && \
+    echo 4694bc007a5bbe34bb7b708d454e8a27f222adbbe2a32cc4d3f336afbcde545e  ps2dev-ubuntu-latest.tar.gz | sha256sum --check && \
     tar xzf ps2dev-ubuntu-latest.tar.gz && \
     rm ps2dev-ubuntu-latest.tar.gz
 
@@ -21,4 +21,3 @@ ENV PS2SDK=/ps2dev/ps2sdk
 ENV GSKIT=/ps2dev/gsKit
 
 CMD echo 'usage: docker run --rm --mount type=bind,source="$(pwd)",destination=/sm64 sm64 make VERSION=${VERSION:-us} -j4'
-


### PR DESCRIPTION
This change is somewhat fragile - I would have used the 1.3.0 binaries but the release seems to be broken (https://github.com/ps2dev/ps2dev/issues/45). I can update the Dockerfile if the above issue is fixed -- this will work until they release a new dev version... better than nothing :)