### PR TITLE
Enforce LF Endings in Python Scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,5 +22,5 @@
 *.png binary
 *.aiff binary
 
-# Declare files that will always have CRLF line endings on checkout.
+# Declare files that will always have LF line endings on checkout.
 *.py text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,6 @@
 *.m64 binary
 *.png binary
 *.aiff binary
+
+# Declare files that will always have CRLF line endings on checkout.
+*.py text eol=lf


### PR DESCRIPTION
This should fix the line ending issue (https://github.com/fgsfdsfgs/sm64-port/issues/37#issuecomment-917444878) by forcing all .py files to use LF line endings. Should be fine as long as the scripts are only being run when compiling on Linux or with Docker.

It's possible that previous attempts to correct this were accidentally undone by Git's `core.autocrlf`

> Git can handle this by auto-converting CRLF line endings into LF when you add a file to the index, and vice versa when it checks out code onto your filesystem. You can turn on this functionality with the core.autocrlf setting. If you’re on a Windows machine, set it to true — this converts LF endings into CRLF when you check out code

https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration