### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:18.04 as build
-
+FROM ubuntu:latest as build
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
         binutils-mips-linux-gnu \


### PR DESCRIPTION
Force docker to work with latest available ubuntu to avoid glibc errors. 

Also above change makes it ask you for time zone selection which doesn't take input for some reason. Solved it by making it non interactive.