### PR TITLE
Fix game not saving due to impossible check

### DIFF
--- a/src/pc/ps2_memcard.c
+++ b/src/pc/ps2_memcard.c
@@ -158,12 +158,13 @@ static inline bool memcard_check(void) {
 bool ps2_memcard_init(void) {
     int ret = -1;
     ret = init_memcard_driver(true);
-    if(ret != 1) {
+    if(ret < 0) {
         printf("ps2_memcard: failed to init memcard driver: %d\n", ret);
         return false;
     }
 
     ret = mcInit(MC_TYPE_XMC);
+    if (ret < 0) ret = mcInit(MC_TYPE_MC);
     if (ret < 0) {
         printf("ps2_memcard: mcInit failed: %d\n", ret);
         return false;

--- a/src/pc/ps2_memcard.c
+++ b/src/pc/ps2_memcard.c
@@ -158,12 +158,12 @@ static inline bool memcard_check(void) {
 bool ps2_memcard_init(void) {
     int ret = -1;
     ret = init_memcard_driver(true);
-    if(ret != 0) {
+    if(ret != 1) {
         printf("ps2_memcard: failed to init memcard driver: %d\n", ret);
         return false;
     }
 
-    ret = mcInit(MC_TYPE_MC);
+    ret = mcInit(MC_TYPE_XMC);
     if (ret < 0) {
         printf("ps2_memcard: mcInit failed: %d\n", ret);
         return false;


### PR DESCRIPTION
- init_memcard_driver never returns 0 but does also return 1 as an OK
- Both emulators and PS2 hardware would stall at mcInit(MC_TYPE_MC), changing it to mcInit(MC_TYPE_XMC) allows saving 