### PR TITLE
Fix saves on PS2

### DIFF
--- a/src/pc/ps2_memcard.c
+++ b/src/pc/ps2_memcard.c
@@ -157,11 +157,6 @@ static inline bool memcard_check(void) {
 
 bool ps2_memcard_init(void) {
     int ret = -1;
-    ret = init_memcard_driver(true);
-    if(ret < 0) {
-        printf("ps2_memcard: failed to init memcard driver: %d\n", ret);
-        return false;
-    }
 
     ret = mcInit(MC_TYPE_XMC);
     if (ret < 0) ret = mcInit(MC_TYPE_MC);


### PR DESCRIPTION
The memory card driver was being initialized twice on `init_drivers`
https://github.com/fgsfdsfgs/sm64-port/blob/822a74046d8a59edff1e30fb1ce622ad55f4a921/src/pc/pc_main.c#L156-L159

It gets called first in:
https://github.com/fjtrujy/ps2_drivers/blob/1079e3a041c312287ab2d584ddd64d799f2dc9c0/src/ps2_filesystem_driver.c#L103 (i can't make this quote work for some strange reason)

And the second time here:
https://github.com/fgsfdsfgs/sm64-port/blob/822a74046d8a59edff1e30fb1ce622ad55f4a921/src/pc/ps2_memcard.c#L160

Would likely fix #80, tested with success on my SCPH-90001 (NTSC) 