### PR TITLE
Add PS2DEV env variable to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN wget https://github.com/ps2dev/ps2dev/releases/download/latest/ps2dev-ubuntu
 RUN mkdir /sm64
 WORKDIR /sm64
 ENV PATH="/ps2dev/ee/bin:/ps2dev/iop/bin:/sm64/tools:${PATH}"
+ENV PS2DEV=/ps2dev
 ENV PS2SDK=/ps2dev/ps2sdk
 ENV GSKIT=/ps2dev/gsKit
 


### PR DESCRIPTION
I found that gskit path defined through PS2DEV in makefile and substitutes to empty string when building using docker. So i added missing environment variable.
![image](https://github.com/user-attachments/assets/74556e2f-c0a5-47bf-b45d-125675143284)
