### PR TITLE
[PS2] Reduce IOP ram

### DIFF
--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -155,12 +155,17 @@ static void prepare_IOP() {
 }
 
 static void init_drivers() {
-	init_ps2_filesystem_driver();
+    // This will try to load only the drivers from the unit where the game is running
+    init_only_boot_ps2_filesystem_driver();
+    // But also require to load manually the memcard driver, as maybe the game is running on a different unit
+    // and we're using the memory card to save/load game data
+    init_memcard_driver(true);
     ps2_memcard_init();
 }
 
 static void deinit_drivers() {
-	deinit_ps2_filesystem_driver();
+    deinit_memcard_driver(true);
+    deinit_only_boot_ps2_filesystem_driver();
 }
 #endif
 


### PR DESCRIPTION
## Description
Avoid loading unnecessary IOP modules, saving IOP RAM, which fixes the issues when launching the game from OPL with SMB.

Confirmed to work with @freshollie

Cheers