### PR TITLE
Update of the repo to allow compilation today

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ ENV PATH=${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
 RUN mkdir /sm64
 WORKDIR /sm64
 
-CMD echo 'usage: docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make VERSION=${VERSION:-xx}\n'
+CMD echo 'usage: docker run --rm -v $(pwd):/sm64 sm64_ps3 make VERSION=xx build/xx_ps3/sm64.xx.f3dex2e.pkg ICON0=ICON0.PNG -j$(nproc)\n'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,33 @@
-FROM ubuntu:18.04 as ps3toolchain
+FROM ubuntu:22.04 AS ps3toolchain
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
   apt-get -y update && \
   apt-get -y install \
-  autoconf bison build-essential ca-certificates flex git libelf-dev\
-  libgmp-dev libncurses5-dev libssl-dev libtool-bin pkg-config python-dev \
-  texinfo wget zlib1g-dev && \
+  autoconf automake bison flex gcc libelf-dev make \
+  texinfo libncurses5-dev patch python-is-python3 subversion wget zlib1g-dev build-essential \
+  libtool libtool-bin python-dev-is-python3 bzip2 libgmp3-dev pkg-config g++ libssl-dev clang && \
   apt-get -y clean autoclean autoremove && \
   rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 RUN mkdir /build
 WORKDIR /build
 
-COPY . /build
+COPY ./ps3toolchain /build
 
 # Fixes certificate errors with letsencrypt in ARMv7
 RUN echo "\nca_certificate=/etc/ssl/certs/ca-certificates.crt" | tee -a /etc/wgetrc
 
-ENV PS3DEV /ps3dev
-ENV PSL1GHT ${PS3DEV}
-ENV PATH ${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
+ENV PS3DEV=/ps3dev
+ENV PSL1GHT=${PS3DEV}
+ENV PATH=${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
 
 RUN /build/toolchain.sh
 
 ###
 
-FROM ubuntu:18.04 as build
+FROM ubuntu:22.04 AS build
 
 RUN apt-get update && \
   apt-get install -y \
@@ -49,11 +49,11 @@ RUN wget http://developer.download.nvidia.com/cg/Cg_3.1/Cg-3.1_April2012_x86_64.
 
 COPY --from=ps3toolchain /ps3dev /ps3dev
 
-ENV PS3DEV /ps3dev
-ENV PSL1GHT ${PS3DEV}
-ENV PATH ${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
+ENV PS3DEV=/ps3dev
+ENV PSL1GHT=${PS3DEV}
+ENV PATH=${PATH}:${PS3DEV}/bin:${PS3DEV}/ppu/bin:${PS3DEV}/spu/bin
 
 RUN mkdir /sm64
 WORKDIR /sm64
 
-CMD echo 'usage: docker run --rm -v $(pwd):/sm64 sm64 make VERSION=${VERSION:-us} -j4\n'
+CMD echo 'usage: docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make VERSION=${VERSION:-xx}\n'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A prior copy of the game is required to extract the assets.
 0. Ensure Git and Docker are installed on your system.
 1. Check out repo, submodules, etc:
 ```
-git clone https://github.com/sdiraimondo/sm64-port.git -b ps3 --recursive
+git clone https://github.com/sdiraimondo/sm64-ps3-port.git -b ps3 --recursive
 cd sm64-port
 ```
 2. Copy in your baserom.XX.z64: `cp /path/to/baserom.us.z64 .`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Super Mario 64 Port
+# Super Mario 64 Port - PS3 Port
 
+- The PS3 port is still in development. Expect issues.
 - This repo contains a full decompilation of Super Mario 64 (J), (U), and (E) with minor exceptions in the audio subsystem.
 - Naming and documentation of the source code and data structures are in progress.
 - Efforts to decompile the Shindou ROM steadily advance toward a matching build.
@@ -8,16 +9,12 @@
 This repo does not include all assets necessary for compiling the game.
 A prior copy of the game is required to extract the assets.
 
-## Building PS3 executables
-
-The PS3 port is still in development. Expect issues.
-
 ### Using Docker
 
 0. Ensure Git and Docker are installed on your system.
 1. Check out repo, submodules, etc:
 ```
-git clone https://github.com/fgsfdsfgs/sm64-port.git -b ps3 --recursive
+git clone https://github.com/sdiraimondo/sm64-port.git -b ps3 --recursive
 cd sm64-port
 ```
 2. Copy in your baserom.XX.z64: `cp /path/to/baserom.us.z64 .`

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ sm64
 
 ## Contributing
 
-Pull requests are welcome. For major changes, please open an issue first to
-discuss what you would like to change.
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+Official Discord: [https://discord.gg/7bcNTPK](https://discord.gg/7bcNTPK)
 
 Run `clang-format` on your code to ensure it meets the project's coding standards.

--- a/README.md
+++ b/README.md
@@ -139,5 +139,3 @@ Pull requests are welcome. For major changes, please open an issue first to
 discuss what you would like to change.
 
 Run `clang-format` on your code to ensure it meets the project's coding standards.
-
-Official Discord: https://discord.gg/7bcNTPK

--- a/README.md
+++ b/README.md
@@ -4,89 +4,101 @@
 - This repo contains a full decompilation of Super Mario 64 (J), (U), and (E) with minor exceptions in the audio subsystem.
 - Naming and documentation of the source code and data structures are in progress.
 - Efforts to decompile the Shindou ROM steadily advance toward a matching build.
-- Beyond Nintendo 64, it can also target Linux and Windows natively.
 
 This repo does not include all assets necessary for compiling the game.
 A prior copy of the game is required to extract the assets.
 
-### Using Docker
+## Using Docker
 
 0. Ensure Git and Docker are installed on your system.
-1. Check out repo, submodules, etc:
+1. Check out repo, submodules, etc.:
 ```
-git clone https://github.com/sdiraimondo/sm64-ps3-port.git -b ps3 --recursive
-cd sm64-port
+git clone https://github.com/Aaahoo13/sm64-ps3-port.git -b ps3 --recursive && cd sm64-ps3-port
 ```
-2. Copy in your baserom.XX.z64: `cp /path/to/baserom.us.z64 .`
-3. Build Docker image: `docker build . -t sm64_ps3`
-4. Compile using your Docker image: `docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make --jobs`
+2. Clone the repo ps3toolchain:
+```
+git clone https://github.com/ps3dev/ps3toolchain.git
+```
+3. Add 3 lines in ps3toolchain's script "009-ps3libraries.sh" to update the links in order to download `libxml2-2.7.8`, use `tar.xz` in lieu of `tar.gz`, and download `freetype-2.4.3`:
+```
+awk '
+/rm -Rf ps3libraries && mkdir ps3libraries && tar --strip-components=1 --directory=ps3libraries -xvzf ps3libraries.tar.gz && cd ps3libraries/ {
+    print
+    print "sed -i '\''s|http://xmlsoft.org/download/libxml2-2.7.8.tar.gz|https://download.gnome.org/sources/libxml2/2.7/libxml2-2.7.8.tar.xz|g'\'' scripts/012-libxml2-2.7.8.sh"
+    print "sed -i '\''s|xfvz libxml2-2.7.8.tar.gz|xfvJ libxml2-2.7.8.tar.xz|g'\'' scripts/012-libxml2-2.7.8.sh"
+    print "sed -i '\''s|http://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz|https://download-mirror.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz|g'\'' scripts/004-freetype-2.4.3.sh"
+    next
+}
+{ print }
+' ps3toolchain/scripts/009-ps3libraries.sh > /tmp/ps3lib && mv /tmp/ps3lib ps3toolchain/scripts/009-ps3libraries.sh
+```
+4. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
+```
+cp /path/to/baserom.<region>.z64 .
+```
+5. Build Docker image:
+```
+docker build . -t sm64_ps3
+```
+6. Compile using your Docker image.  
+You can precise the region with `VERSION=<region>`, where &lt;region> can be us, jp, or eu (us is default).  
+You can also add `-j4` if ou have 4 cores, for instance, or `-j$(nproc)` if you want to use all the cores and you base your Docker image on Debian instead of Ubuntu.
+```
+docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make VERSION=<region> -j4
+```
+The resulting .self will be in `build/<region>_ps3/`.
 
-Alternatively instead of steps 3 and 4 you can use a prebuilt Docker image provided by mkst:
-```docker run --rm -ti -v $(pwd):/sm64 markstreet/sm64:ps3 make --jobs```
+7. In order to produce the .pkg file, you can have the default PSL1GHT icon without music nor background picture:
+```
+docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make build/<region>_ps3/sm64.<region>.f3dex2e.pkg
+```
+To avoid having the default PSL1GHT icon, copy the correct icon (320×176) with the name "ICON0.PNG" into the repository's root directory, and change the Makefile:
+```
+sed -i 's/ICON0[[:space:]]*:=/ICON0     ?=/g' Makefile
+```
+```
+docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make build/<region>_ps3/sm64.<region>.f3dex2e.pkg ICON0=ICON0.PNG
+```
+To add the possibility of having a music and background picture, you'll have to copy the audio file (ATRAC3 / ATRAC3+) and picture (1920×1080), then modify the Makefile:
+```
+sed -i '/ICON0[[:space:]]*?=/a\
+  PIC1      ?= PIC1.PNG\
+  SND0      ?= SND0.AT3' Makefile
+```
+```
+sed -i '/cp $(ICON0)*/a\
+\tcp $(PIC1) $(BUILD_DIR)/pkg/PIC1.PNG\
+\tcp $(SND0) $(BUILD_DIR)/pkg/SND0.AT3' Makefile
+```
+You can then produce the .pkg file with the desired icon, music and background picture. Add `-j4` to improve build speed (hardware dependent based on the amount of CPU cores available):
+```
+docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make build/<region>_ps3/sm64.<region>.f3dex2e.pkg ICON0=ICON0.PNG -j4
+```
 
-### Manually under Linux (WSL and MSYS2 not tested)
+## Manually under Linux (WSL and MSYS2 not tested)
 
-0. Ensure Git, GCC, GNU Make and Python 3 are installed on your system:
+0. Ensure Git, GCC, GNU Make and Python 3 are installed on your system :
 ```
 # for example on Ubuntu
 sudo apt install git build-essential python3
 ```
-1. Ensure PSL1GHT is installed on your system and the environmental variables `PS3DEV` and `PSL1GHT` are defined and PSL1GHT is in your `PATH`.
+1. Check out repo, submodules, etc.: 
+```
+git clone https://github.com/Aaahoo13/sm64-ps3-port.git -b ps3 --recursive && cd sm64-ps3-port
+```
+2. Clone the repo ps3toolchain:
+```
+git clone https://github.com/ps3dev/ps3toolchain.git
+```
+3. Same step as the step 3 in the Docker version to update the links in order to download `libxml2-2.7.8`, use `tar.xz` in lieu of `tar.gz`, and download `freetype-2.4.3`.
+4. Ensure PSL1GHT is installed on your system and the environmental variables `PS3DEV` and `PSL1GHT` are defined and PSL1GHT is in your `PATH`.
 You can follow the installation instructions in the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain).
-2. Install [Cg Toolkit](https://developer.nvidia.com/cg-toolkit-download).
-3. Check out repo, submodules, etc:
+5. Install [Cg Toolkit](https://developer.nvidia.com/cg-toolkit-download).
+6. Copy in your `baserom.&lt;region>.z64`, where &lt;region> can be us, jp, or eu:
 ```
-git clone https://github.com/fgsfdsfgs/sm64-port.git -b ps3 --recursive
-cd sm64-port
+cp /path/to/baserom.<region>.z64 .
 ```
-4. Copy in your baserom.XX.z64: `cp /path/to/baserom.us.z64 .`
-5. Compile: `make -j4`
-
-In both cases, the resulting SELF will be in `build/<region>_ps3/`.
-
-There is also an untested PKG target in the Makefile, which can be used like so (replace `us` with your region of choice if needed):
-```make build/us_ps3/sm64.us.f3dex2e.pkg```
-
-The resulting PKG file will be in the same directory as the SELF.
-
-## Building native executables
-
-### Linux
-
-1. Install prerequisites (Ubuntu): `sudo apt install -y git build-essential pkg-config libusb-1.0-0-dev libsdl2-dev`.
-2. Clone the repo: `git clone https://github.com/sm64-port/sm64-port.git`, which will create a directory `sm64-port` and then **enter** it `cd sm64-port`.
-3. Place a Super Mario 64 ROM called `baserom.<VERSION>.z64` into the repository's root directory for asset extraction, where `VERSION` can be `us`, `jp`, or `eu`.
-4. Run `make` to build. Qualify the version through `make VERSION=<VERSION>`. Add `-j4` to improve build speed (hardware dependent based on the amount of CPU cores available).
-5. The executable binary will be located at `build/<VERSION>_pc/sm64.<VERSION>.f3dex2e`.
-
-### Windows
-
-1. Install and update MSYS2, following all the directions listed on https://www.msys2.org/.
-2. From the start menu, launch MSYS2 MinGW and install required packages depending on your machine (do **NOT** launch "MSYS2 MSYS"):
-  * 64-bit: Launch "MSYS2 MinGW 64-bit" and install: `pacman -S git make python3 mingw-w64-x86_64-gcc`
-  * 32-bit (will also work on 64-bit machines): Launch "MSYS2 MinGW 32-bit" and install: `pacman -S git make python3 mingw-w64-i686-gcc`
-  * Do **NOT** by mistake install the package called simply `gcc`.
-3. The MSYS2 terminal has a _current working directory_ that initially is `C:\msys64\home\<username>` (home directory). At the prompt, you will see the current working directory in yellow. `~` is an alias for the home directory. You can change the current working directory to `My Documents` by entering `cd /c/Users/<username>/Documents`.
-4. Clone the repo: `git clone https://github.com/sm64-port/sm64-port.git`, which will create a directory `sm64-port` and then **enter** it `cd sm64-port`.
-5. Place a *Super Mario 64* ROM called `baserom.<VERSION>.z64` into the repository's root directory for asset extraction, where `VERSION` can be `us`, `jp`, or `eu`.
-6. Run `make` to build. Qualify the version through `make VERSION=<VERSION>`. Add `-j4` to improve build speed (hardware dependent based on the amount of CPU cores available).
-7. The executable binary will be located at `build/<VERSION>_pc/sm64.<VERSION>.f3dex2e.exe` inside the repository.
-
-#### Troubleshooting
-
-1. If you get `make: gcc: command not found` or `make: gcc: No such file or directory` although the packages did successfully install, you probably launched the wrong MSYS2. Read the instructions again. The terminal prompt should contain "MINGW32" or "MINGW64" in purple text, and **NOT** "MSYS".
-2. If you get `Failed to open baserom.us.z64!` you failed to place the baserom in the repository. You can write `ls` to list the files in the current working directory. If you are in the `sm64-port` directory, make sure you see it here.
-3. If you get `make: *** No targets specified and no makefile found. Stop.`, you are not in the correct directory. Make sure the yellow text in the terminal ends with `sm64-port`. Use `cd <dir>` to enter the correct directory. If you write `ls` you should see all the project files, including `Makefile` if everything is correct.
-4. If you get any error, be sure MSYS2 packages are up to date by executing `pacman -Syu` and `pacman -Su`. If the MSYS2 window closes immediately after opening it, restart your computer.
-5. When you execute `gcc -v`, be sure you see `Target: i686-w64-mingw32` or `Target: x86_64-w64-mingw32`. If you see `Target: x86_64-pc-msys`, you either opened the wrong MSYS start menu entry or installed the incorrect gcc package.
-
-### Debugging
-
-The code can be debugged using `gdb`. On Linux install the `gdb` package and execute `gdb <executable>`. On MSYS2 install by executing `pacman -S winpty gdb` and execute `winpty gdb <executable>`. The `winpty` program makes sure the keyboard works correctly in the terminal. Also consider changing the `-mwindows` compile flag to `-mconsole` to be able to see stdout/stderr as well as be able to press Ctrl+C to interrupt the program. In the Makefile, make sure you compile the sources using `-g` rather than `-O2` to include debugging symbols. See any online tutorial for how to use gdb.
-
-## ROM building
-
-It is possible to build N64 ROMs as well with this repository. See https://github.com/n64decomp/sm64 for instructions.
+7. Follow the same last 2 steps as the Docker version (6 & 7) without `"docker run --rm -ti -v $(pwd):/sm64 sm64_ps3"` at the beginning of the commands.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -19,23 +19,15 @@ git clone https://github.com/Aaahoo13/sm64-ps3-port.git -b ps3 --recursive && cd
 ```
 git clone https://github.com/ps3dev/ps3toolchain.git
 ```
-3. Add 2 lines in ps3toolchain's script "009-ps3libraries.sh" to update the links in order to download `libxml2-2.7.8` and `freetype-2.4.3` (while waiting for [ps3libraries repo](https://github.com/ps3dev/ps3libraries) to be updated):
-```
-sed -i '
-/^rm/ a\
-sed -i "s/download/sources/g" scripts/012-libxml2-2.7.8.sh\
-sed -i "s/download/download-mirror/g" scripts/004-freetype-2.4.3.sh
-' ps3toolchain/scripts/009-ps3libraries.sh
-```
-4. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
+3. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
 ```
 cp /path/to/baserom.<region>.z64 .
 ```
-5. Build Docker image:
+4. Build Docker image:
 ```
 docker build . -t sm64_ps3
 ```
-6. Compile using your Docker image.  
+5. Compile using your Docker image.  
 You can precise the region with `VERSION=<region>`, where &lt;region> can be us, jp, or eu (us is default).  
 You can also add `-j4` if ou have 4 cores, for instance, or `-j$(nproc)` if you want to use all the cores.  
 In order to produce the .pkg file, you can have the default PSL1GHT icon without music nor background picture:
@@ -80,14 +72,13 @@ git clone https://github.com/Aaahoo13/sm64-ps3-port.git -b ps3 --recursive && cd
 ```
 git clone https://github.com/ps3dev/ps3toolchain.git
 ```
-3. Same step as the step 3 in the Docker version to update the links in order to download `libxml2-2.7.8` and `freetype-2.4.3`.
-4. Ensure PSL1GHT is installed on your system and the environmental variables `PS3DEV` and `PSL1GHT` are defined and PSL1GHT is in your `PATH`. You can follow the installation instructions in the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain).
-5. Install [Cg Toolkit](https://developer.nvidia.com/cg-toolkit-download).
-6. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
+3. Ensure PSL1GHT is installed on your system and the environmental variables `PS3DEV` and `PSL1GHT` are defined and PSL1GHT is in your `PATH`. You can follow the installation instructions in the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain).
+4. Install [Cg Toolkit](https://developer.nvidia.com/cg-toolkit-download).
+5. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
 ```
 cp /path/to/baserom.<region>.z64 .
 ```
-7. Follow the same last step as the Docker version without `docker run --rm -v $(pwd):/sm64 sm64_ps3` at the beginning of the commands.
+6. Follow the same last step as the Docker version without `docker run --rm -v $(pwd):/sm64 sm64_ps3` at the beginning of the commands.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,17 @@ A prior copy of the game is required to extract the assets.
 ```
 git clone https://github.com/Aaahoo13/sm64-ps3-port.git -b ps3 --recursive && cd sm64-ps3-port
 ```
-2. Clone the repo ps3toolchain:
+2. Clone the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain):
 ```
 git clone https://github.com/ps3dev/ps3toolchain.git
 ```
-3. Add 3 lines in ps3toolchain's script "009-ps3libraries.sh" to update the links in order to download `libxml2-2.7.8`, use `tar.xz` in lieu of `tar.gz`, and download `freetype-2.4.3`:
+3. Add 2 lines in ps3toolchain's script "009-ps3libraries.sh" to update the links in order to download `libxml2-2.7.8` and `freetype-2.4.3` (while waiting for [ps3libraries repo](https://github.com/ps3dev/ps3libraries) to be updated):
 ```
-awk '
-/rm -Rf ps3libraries && mkdir ps3libraries && tar --strip-components=1 --directory=ps3libraries -xvzf ps3libraries.tar.gz && cd ps3libraries/ {
-    print
-    print "sed -i '\''s|http://xmlsoft.org/download/libxml2-2.7.8.tar.gz|https://download.gnome.org/sources/libxml2/2.7/libxml2-2.7.8.tar.xz|g'\'' scripts/012-libxml2-2.7.8.sh"
-    print "sed -i '\''s|xfvz libxml2-2.7.8.tar.gz|xfvJ libxml2-2.7.8.tar.xz|g'\'' scripts/012-libxml2-2.7.8.sh"
-    print "sed -i '\''s|http://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz|https://download-mirror.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.4.3.tar.gz|g'\'' scripts/004-freetype-2.4.3.sh"
-    next
-}
-{ print }
-' ps3toolchain/scripts/009-ps3libraries.sh > /tmp/ps3lib && mv /tmp/ps3lib ps3toolchain/scripts/009-ps3libraries.sh
+sed -i '
+/^rm/ a\
+sed -i "s/download/sources/g" scripts/012-libxml2-2.7.8.sh\
+sed -i "s/download/download-mirror/g" scripts/004-freetype-2.4.3.sh
+' ps3toolchain/scripts/009-ps3libraries.sh
 ```
 4. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
 ```
@@ -42,24 +37,19 @@ docker build . -t sm64_ps3
 ```
 6. Compile using your Docker image.  
 You can precise the region with `VERSION=<region>`, where &lt;region> can be us, jp, or eu (us is default).  
-You can also add `-j4` if ou have 4 cores, for instance, or `-j$(nproc)` if you want to use all the cores and you base your Docker image on Debian instead of Ubuntu.
+You can also add `-j4` if ou have 4 cores, for instance, or `-j$(nproc)` if you want to use all the cores.  
+In order to produce the .pkg file, you can have the default PSL1GHT icon without music nor background picture:
 ```
-docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make VERSION=<region> -j4
-```
-The resulting .self will be in `build/<region>_ps3/`.
-
-7. In order to produce the .pkg file, you can have the default PSL1GHT icon without music nor background picture:
-```
-docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make build/<region>_ps3/sm64.<region>.f3dex2e.pkg
+docker run --rm -v $(pwd):/sm64 sm64_ps3 make VERSION=<region> build/<region>_ps3/sm64.<region>.f3dex2e.pkg -j$(nproc)
 ```
 To avoid having the default PSL1GHT icon, copy the correct icon (320×176) with the name "ICON0.PNG" into the repository's root directory, and change the Makefile:
 ```
 sed -i 's/ICON0[[:space:]]*:=/ICON0     ?=/g' Makefile
 ```
 ```
-docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make build/<region>_ps3/sm64.<region>.f3dex2e.pkg ICON0=ICON0.PNG
+docker run --rm -v $(pwd):/sm64 sm64_ps3 make VERSION=<region> build/<region>_ps3/sm64.<region>.f3dex2e.pkg ICON0=ICON0.PNG -j$(nproc)
 ```
-To add the possibility of having a music and background picture, you'll have to copy the audio file (ATRAC3 / ATRAC3+) and picture (1920×1080), then modify the Makefile:
+To add the possibility of having a background picture and music, you'll have to copy the picture (1920×1080) with the name "PIC1.PNG" and audio file (ATRAC3 / ATRAC3+) with the name "SND0.AT3" into the repository's root directory, then modify the Makefile:
 ```
 sed -i '/ICON0[[:space:]]*?=/a\
   PIC1      ?= PIC1.PNG\
@@ -70,9 +60,9 @@ sed -i '/cp $(ICON0)*/a\
 \tcp $(PIC1) $(BUILD_DIR)/pkg/PIC1.PNG\
 \tcp $(SND0) $(BUILD_DIR)/pkg/SND0.AT3' Makefile
 ```
-You can then produce the .pkg file with the desired icon, music and background picture. Add `-j4` to improve build speed (hardware dependent based on the amount of CPU cores available):
+You can then produce the .pkg file with the desired icon, music and background picture:
 ```
-docker run --rm -ti -v $(pwd):/sm64 sm64_ps3 make build/<region>_ps3/sm64.<region>.f3dex2e.pkg ICON0=ICON0.PNG -j4
+docker run --rm -v $(pwd):/sm64 sm64_ps3 make VERSION=<region> build/<region>_ps3/sm64.<region>.f3dex2e.pkg ICON0=ICON0.PNG -j$(nproc)
 ```
 
 ## Manually under Linux (WSL and MSYS2 not tested)
@@ -86,19 +76,18 @@ sudo apt install git build-essential python3
 ```
 git clone https://github.com/Aaahoo13/sm64-ps3-port.git -b ps3 --recursive && cd sm64-ps3-port
 ```
-2. Clone the repo ps3toolchain:
+2. Clone the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain):
 ```
 git clone https://github.com/ps3dev/ps3toolchain.git
 ```
-3. Same step as the step 3 in the Docker version to update the links in order to download `libxml2-2.7.8`, use `tar.xz` in lieu of `tar.gz`, and download `freetype-2.4.3`.
-4. Ensure PSL1GHT is installed on your system and the environmental variables `PS3DEV` and `PSL1GHT` are defined and PSL1GHT is in your `PATH`.
-You can follow the installation instructions in the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain).
+3. Same step as the step 3 in the Docker version to update the links in order to download `libxml2-2.7.8` and `freetype-2.4.3`.
+4. Ensure PSL1GHT is installed on your system and the environmental variables `PS3DEV` and `PSL1GHT` are defined and PSL1GHT is in your `PATH`. You can follow the installation instructions in the [ps3toolchain repo](https://github.com/ps3dev/ps3toolchain).
 5. Install [Cg Toolkit](https://developer.nvidia.com/cg-toolkit-download).
-6. Copy in your `baserom.&lt;region>.z64`, where &lt;region> can be us, jp, or eu:
+6. Copy in your `baserom.<region>.z64`, where &lt;region> can be us, jp, or eu:
 ```
 cp /path/to/baserom.<region>.z64 .
 ```
-7. Follow the same last 2 steps as the Docker version (6 & 7) without `"docker run --rm -ti -v $(pwd):/sm64 sm64_ps3"` at the beginning of the commands.
+7. Follow the same last step as the Docker version without `docker run --rm -v $(pwd):/sm64 sm64_ps3` at the beginning of the commands.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ sm64
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
-Official Discord: [https://discord.gg/7bcNTPK](https://discord.gg/7bcNTPK)
-
 Run `clang-format` on your code to ensure it meets the project's coding standards.
+
+Official Discord: [https://discord.gg/7bcNTPK](https://discord.gg/7bcNTPK)

--- a/src/pc/gfx/gfx_ps3_rapi.c
+++ b/src/pc/gfx/gfx_ps3_rapi.c
@@ -447,7 +447,6 @@ static inline void draw_set_environment(void) {
     rsxSetColorMaskMrt(rsx_ctx, 0);
     rsxSetClearColor(rsx_ctx, 0);
     rsxSetClearDepthStencil(rsx_ctx, 0xffffff00);
-    rsxSetZControl(rsx_ctx, 1, 1, 0);
     rsxSetUserClipPlaneControl(
         rsx_ctx,
         GCM_USER_CLIP_PLANE_DISABLE,


### PR DESCRIPTION
- Correction of the directory from `sm64-port` to `sm64-ps3-port`.
- Added `git clone https://github.com/ps3dev/ps3toolchain.git`.
- Correction of the Dockerfile: compliance with the official Docker syntax, images based on ubuntu:22.04, the right packages, the right source path to copy ps3toolchain files, and CMD line correction (docker run usage).
- Remove redundant rsxSetZControl call: The call to `rsxSetZControl(rsx_ctx, 1, 1, 0)` has been removed from `src/pc/gfx/gfx_ps3_rapi.c`, since depth testing and depth writes are already correctly configured in `static inline void draw_set_environment(void)` via `rsxSetDepthTestEnable`, `rsxSetDepthWriteEnable`, and `rsxSetDepthFunc`.
- Added the possibility to generate .pkg file with a custom icon, background picture and music.
- Removed the "Building native executables" part.